### PR TITLE
Improve UX: venv discovery, config persistence, seamless permissions

### DIFF
--- a/.claude/skills/pymol-connect/SKILL.md
+++ b/.claude/skills/pymol-connect/SKILL.md
@@ -5,52 +5,6 @@ description: Use when launching PyMOL or connecting to an existing PyMOL session
 
 # PyMOL Connect
 
-Establish a connection to PyMOL for molecular visualization work.
+This skill has been merged into `/pymol`. Use that instead.
 
-## Connection Flow
-
-Follow these steps in order. Stop as soon as you're connected.
-
-### Step 1: Check the SessionStart hook output
-
-The hook runs `claudemol status` automatically. Read its output:
-- **"Socket connection: OK"** → PyMOL is running. Go to Step 3.
-- **"Socket connection: Not available"** → PyMOL is installed but not running. Go to Step 2.
-- **"PyMOL not found"** → PyMOL is not installed. Tell the user to run `pip install claudemol && claudemol setup`, then start PyMOL manually.
-
-### Step 2: Launch PyMOL
-
-Only if no existing PyMOL is running:
-
-```python
-from claudemol import launch_pymol
-process = launch_pymol()
-```
-
-This launches PyMOL with the socket plugin and waits for it to be ready.
-
-### Step 3: Connect and verify
-
-```python
-from claudemol import PyMOLConnection
-conn = PyMOLConnection()
-conn.connect()
-result = conn.execute("print('connected')")
-```
-
-**Reuse this `conn` object for all subsequent commands.** Do not create a new connection each time.
-
-## Rules
-
-- **Never use `PyMOLSession`** — its recovery mode kills existing PyMOL sessions.
-- **Never call `cmd.reinitialize()`** unless the user explicitly asks.
-- **If connection drops mid-session**, `conn.execute()` auto-reconnects. Do not create a new connection or relaunch PyMOL.
-- **If PyMOL crashes**, tell the user and offer to relaunch.
-
-## Refer to Other Skills
-
-For specific visualization tasks, use:
-- @pymol-fundamentals - selections, representations, colors
-- @binding-site-visualization - ligand binding sites
-- @publication-figures - high-quality figures
-- @structure-alignment-analysis - comparing structures
+@pymol - Launch or connect to PyMOL

--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -7,25 +7,54 @@ claudemol connects Claude to a running PyMOL instance over TCP socket (localhost
 1. **Check status first.** The SessionStart hook runs `claudemol status` automatically. Read its output before doing anything.
 2. **Never kill an existing PyMOL session.** If PyMOL is already running, connect to it. Do not launch a new instance.
 3. **Never call `cmd.reinitialize()` unless the user explicitly asks.** This destroys all loaded structures.
-4. **Use `PyMOLConnection`, not `PyMOLSession`.** PyMOLSession's auto-recovery is too aggressive and kills existing sessions.
+4. **Use `connect_or_launch()` for new connections.** It connects to an existing PyMOL or launches one if needed.
 
 ## Canonical Connection Pattern
 
 ```python
-from claudemol import PyMOLConnection
-conn = PyMOLConnection()
-conn.connect()
+from claudemol import connect_or_launch
+conn, process = connect_or_launch()
 conn.execute("fetch 1ubq")
 ```
 
 Reuse the `conn` object across commands. If connection drops, `conn.execute()` auto-reconnects (3 attempts).
 
-If PyMOL is not running: tell the user, or use `from claudemol import launch_pymol; launch_pymol()`.
+## Venv Discovery
+
+If `from claudemol import ...` fails (ModuleNotFoundError), check `~/.claudemol/config.json` for the persisted Python path:
+
+```python
+import json, subprocess
+from pathlib import Path
+config = json.loads((Path.home() / ".claudemol" / "config.json").read_text())
+python_path = config["python_path"]
+# Use: subprocess.run([python_path, "-c", "from claudemol import ..."])
+```
+
+Also check the project venv: `.venv/bin/python -c "import claudemol"`.
 
 ## Image Capture
 
 Always use: `cmd.ray(width, height)` then `cmd.png(path)`.
-Never use: `cmd.png(path, width, height)` — causes view corruption.
+Never use: `cmd.png(path, width, height)` -- causes view corruption.
+
+## Recommended Permissions
+
+For seamless PyMOL interaction without per-command approval prompts, users can add these to their project's `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(claudemol*)",
+      "Bash(*python*claudemol*)",
+      "Bash(pymol*)"
+    ]
+  }
+}
+```
+
+This allows: claudemol CLI commands, Python scripts that use claudemol, and PyMOL launches. Suggest this to users during `/pymol-setup` if they haven't configured it.
 
 ## Skills
 

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "claudemol status 2>/dev/null || echo 'claudemol not installed or PyMOL not running'",
+            "command": "claudemol status 2>/dev/null || (python_path=$(python3 -c \"import json,pathlib; c=json.loads(pathlib.Path.home().joinpath('.claudemol','config.json').read_text()); print(c['python_path'])\" 2>/dev/null) && \"$python_path\" -m claudemol.cli status 2>/dev/null) || echo 'claudemol not installed or PyMOL not running'",
             "timeout": 10
           }
         ]

--- a/claude-plugin/skills/pymol-connect/SKILL.md
+++ b/claude-plugin/skills/pymol-connect/SKILL.md
@@ -5,52 +5,6 @@ description: Use when launching PyMOL or connecting to an existing PyMOL session
 
 # PyMOL Connect
 
-Establish a connection to PyMOL for molecular visualization work.
+This skill has been merged into `/pymol`. Use that instead.
 
-## Connection Flow
-
-Follow these steps in order. Stop as soon as you're connected.
-
-### Step 1: Check the SessionStart hook output
-
-The hook runs `claudemol status` automatically. Read its output:
-- **"Socket connection: OK"** → PyMOL is running. Go to Step 3.
-- **"Socket connection: Not available"** → PyMOL is installed but not running. Go to Step 2.
-- **"PyMOL not found"** → PyMOL is not installed. Tell the user to run `pip install claudemol && claudemol setup`, then start PyMOL manually.
-
-### Step 2: Launch PyMOL
-
-Only if no existing PyMOL is running:
-
-```python
-from claudemol import launch_pymol
-process = launch_pymol()
-```
-
-This launches PyMOL with the socket plugin and waits for it to be ready.
-
-### Step 3: Connect and verify
-
-```python
-from claudemol import PyMOLConnection
-conn = PyMOLConnection()
-conn.connect()
-result = conn.execute("print('connected')")
-```
-
-**Reuse this `conn` object for all subsequent commands.** Do not create a new connection each time.
-
-## Rules
-
-- **Never use `PyMOLSession`** — its recovery mode kills existing PyMOL sessions.
-- **Never call `cmd.reinitialize()`** unless the user explicitly asks.
-- **If connection drops mid-session**, `conn.execute()` auto-reconnects. Do not create a new connection or relaunch PyMOL.
-- **If PyMOL crashes**, tell the user and offer to relaunch.
-
-## Refer to Other Skills
-
-For specific visualization tasks, use:
-- @pymol-fundamentals - selections, representations, colors
-- @binding-site-visualization - ligand binding sites
-- @publication-figures - high-quality figures
-- @structure-alignment-analysis - comparing structures
+@pymol - Launch or connect to PyMOL

--- a/src/claudemol/__init__.py
+++ b/src/claudemol/__init__.py
@@ -6,15 +6,18 @@ Connect to PyMOL via socket for AI-assisted molecular visualization.
 
 from claudemol.connection import (
     PyMOLConnection,
-    connect_or_launch,
-    launch_pymol,
-    find_pymol_command,
     check_pymol_installed,
+    connect_or_launch,
+    find_pymol_command,
+    get_config,
+    get_configured_python,
+    launch_pymol,
+    save_config,
 )
 from claudemol.session import (
     PyMOLSession,
-    get_session,
     ensure_running,
+    get_session,
     stop_pymol,
 )
 
@@ -26,6 +29,9 @@ __all__ = [
     "launch_pymol",
     "find_pymol_command",
     "check_pymol_installed",
+    "get_config",
+    "save_config",
+    "get_configured_python",
     "get_session",
     "ensure_running",
     "stop_pymol",

--- a/src/claudemol/connection.py
+++ b/src/claudemol/connection.py
@@ -17,6 +17,9 @@ DEFAULT_PORT = 9880
 CONNECT_TIMEOUT = 5.0
 RECV_TIMEOUT = 30.0
 
+CONFIG_DIR = Path.home() / ".claudemol"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
 # Common PyMOL installation paths
 PYMOL_PATHS = [
     # uv environment (created by /pymol-setup)
@@ -247,3 +250,28 @@ def connect_or_launch(file_path=None):
     process = launch_pymol(file_path=file_path)
     conn.connect()
     return conn, process
+
+
+def get_config():
+    """Read persisted claudemol config."""
+    if CONFIG_FILE.exists():
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def save_config(config):
+    """Save claudemol config."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def get_configured_python():
+    """Get the Python path from persisted config. Returns path string or None."""
+    config = get_config()
+    python_path = config.get("python_path")
+    if python_path and os.path.isfile(python_path) and os.access(python_path, os.X_OK):
+        return python_path
+    return None


### PR DESCRIPTION
## Summary

- **Config persistence**: `claudemol setup` now saves the Python interpreter path to `~/.claudemol/config.json`. Future sessions read this to find claudemol even when it's in a project venv that isn't in PATH.
- **Smarter SessionStart hook**: Falls back to reading the persisted config when `claudemol` CLI isn't directly available.
- **Merged /pymol and /pymol-connect skills**: One skill with smart logic — checks hook output, uses `connect_or_launch()`, handles venv fallback via config.json.
- **Streamlined /pymol-setup**: Checks project venvs before declaring "not installed". Offers optional permission allowlist for seamless interaction.
- **Permission allowlist**: Three glob patterns (`claudemol*`, `*python*claudemol*`, `pymol*`) auto-approve all PyMOL-related commands.
- **Updated README**: Added plugin install steps, venv discovery docs, permissions guide, and highlighted the integration strength (connecting PyMOL to databases, papers, PLMs).

## Motivation

From a real user session: `/pymol` failed because claudemol was in a project venv, `/pymol-setup` tried to reinstall it, and PyMOL launched twice because the background process appeared to "complete". These changes fix the root causes.

## Test plan

- [ ] Run `claudemol setup` from a project venv, verify `~/.claudemol/config.json` is written
- [ ] Start a new Claude Code session, verify SessionStart hook finds claudemol via config fallback
- [ ] Run `/pymol`, verify it uses `connect_or_launch()` and doesn't double-launch
- [ ] Run `/pymol-setup`, verify it finds claudemol in project venv without trying to reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)