### PR TITLE
Add CLI exec/launch commands and shell wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ claudemol/
 │   ├── session.py        # Session management
 │   ├── view.py           # Visual feedback helpers
 │   ├── plugin.py         # Socket plugin (runs in PyMOL)
-│   └── cli.py            # CLI: claudemol setup|status|test
+│   └── cli.py            # CLI: claudemol setup|status|test|info|launch|exec
 ├── claude-plugin/        # Claude Code plugin
 │   ├── .claude-plugin/
 │   │   └── plugin.json
@@ -26,7 +26,7 @@ claudemol/
 ## Architecture
 
 ```
-Claude Code → TCP Socket (port 9880) → PyMOL Plugin → cmd.* execution
+Claude Code → ~/.claudemol/bin/claudemol exec → TCP Socket (port 9880) → PyMOL Plugin → cmd.* execution
 ```
 
 **Key components:**
@@ -39,9 +39,21 @@ Claude Code → TCP Socket (port 9880) → PyMOL Plugin → cmd.* execution
 
 2. **Connection Module** (`src/claudemol/connection.py`) - Python module for socket communication
    - `PyMOLConnection` class handles TCP socket communication
-   - Used by Claude Code to send commands to PyMOL
+   - Used by CLI commands to send commands to PyMOL
 
-3. **Skills** (`claude-plugin/skills/`) - Workflow guidance for visualization tasks
+3. **CLI** (`src/claudemol/cli.py`) - Command-line interface
+   - `setup` - Configures `~/.pymolrc` and creates `~/.claudemol/bin/claudemol` wrapper
+   - `status` - Checks if PyMOL is running and connected
+   - `test` - Tests connection with a simple command
+   - `info` - Shows installation info
+   - `launch` - Launches PyMOL or connects to existing instance
+   - `exec` - Executes code in PyMOL (positional arg or stdin)
+
+4. **Wrapper Script** (`~/.claudemol/bin/claudemol`) - Created by `claudemol setup`
+   - Bash script with baked Python path from the venv where claudemol is installed
+   - Works from any environment without import issues
+
+5. **Skills** (`claude-plugin/skills/`) - Workflow guidance for visualization tasks
    - Distributed as Claude Code plugin separately from pip package
 
 ## Distribution
@@ -49,7 +61,7 @@ Claude Code → TCP Socket (port 9880) → PyMOL Plugin → cmd.* execution
 **pip package:**
 ```bash
 pip install claudemol
-claudemol setup  # Configures PyMOL to auto-load plugin
+claudemol setup  # Configures PyMOL + creates wrapper script
 ```
 
 **Claude Code skills:**
@@ -81,7 +93,9 @@ pytest tests/
 
 ## Key Code Patterns
 
-- `from claudemol import PyMOLConnection, PyMOLSession` - Main API
+- `~/.claudemol/bin/claudemol exec "cmd.fetch('1ubq')"` - Send commands to PyMOL
+- `~/.claudemol/bin/claudemol launch` - Launch or connect to PyMOL
+- `from claudemol import PyMOLConnection, PyMOLSession` - Python API (used internally by CLI)
 - Global session via `get_session()` with auto-reconnect
 - Plugin handles multiple clients but only one active connection at a time
 - Local skills in `.claude/skills/` for development, `claude-plugin/skills/` for distribution

--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -7,31 +7,26 @@ claudemol connects Claude to a running PyMOL instance over TCP socket (localhost
 1. **Check status first.** The SessionStart hook runs `claudemol status` automatically. Read its output before doing anything.
 2. **Never kill an existing PyMOL session.** If PyMOL is already running, connect to it. Do not launch a new instance.
 3. **Never call `cmd.reinitialize()` unless the user explicitly asks.** This destroys all loaded structures.
-4. **Use `connect_or_launch()` for new connections.** It connects to an existing PyMOL or launches one if needed.
 
 ## Canonical Connection Pattern
 
-```python
-from claudemol import connect_or_launch
-conn, process = connect_or_launch()
-conn.execute("fetch 1ubq")
+```bash
+~/.claudemol/bin/claudemol launch
+~/.claudemol/bin/claudemol exec "cmd.fetch('1ubq')"
 ```
 
-Reuse the `conn` object across commands. If connection drops, `conn.execute()` auto-reconnects (3 attempts).
+All commands go through `~/.claudemol/bin/claudemol exec`. The wrapper script bakes in the correct Python path — no imports, no venv discovery needed.
 
-## Venv Discovery
+For multi-line commands use heredocs:
 
-If `from claudemol import ...` fails (ModuleNotFoundError), check `~/.claudemol/config.json` for the persisted Python path:
-
-```python
-import json, subprocess
-from pathlib import Path
-config = json.loads((Path.home() / ".claudemol" / "config.json").read_text())
-python_path = config["python_path"]
-# Use: subprocess.run([python_path, "-c", "from claudemol import ..."])
+```bash
+~/.claudemol/bin/claudemol exec "$(cat <<'PYMOL'
+cmd.hide('everything')
+cmd.show('cartoon')
+cmd.color('spectrum')
+PYMOL
+)"
 ```
-
-Also check the project venv: `.venv/bin/python -c "import claudemol"`.
 
 ## Image Capture
 
@@ -46,15 +41,14 @@ For seamless PyMOL interaction without per-command approval prompts, users can a
 {
   "permissions": {
     "allow": [
-      "Bash(claudemol*)",
-      "Bash(*python*claudemol*)",
+      "Bash(*/.claudemol/bin/claudemol*)",
       "Bash(pymol*)"
     ]
   }
 }
 ```
 
-This allows: claudemol CLI commands, Python scripts that use claudemol, and PyMOL launches. Suggest this to users during `/pymol-setup` if they haven't configured it.
+Suggest this to users during `/pymol-setup` if they haven't configured it.
 
 ## Skills
 

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "claudemol status 2>/dev/null || (python_path=$(python3 -c \"import json,pathlib; c=json.loads(pathlib.Path.home().joinpath('.claudemol','config.json').read_text()); print(c['python_path'])\" 2>/dev/null) && \"$python_path\" -m claudemol.cli status 2>/dev/null) || echo 'claudemol not installed or PyMOL not running'",
+            "command": "$HOME/.claudemol/bin/claudemol status 2>/dev/null || echo 'claudemol: not configured (run /pymol-setup)'",
             "timeout": 10
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudemol"
-version = "0.3.0"
+version = "0.4.0"
 description = "PyMOL integration for Claude Code - control molecular visualization via natural language"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/claudemol/__init__.py
+++ b/src/claudemol/__init__.py
@@ -21,7 +21,7 @@ from claudemol.session import (
     stop_pymol,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 __all__ = [
     "PyMOLConnection",
     "PyMOLSession",


### PR DESCRIPTION
## Summary

- Add `exec` and `launch` CLI subcommands so skills can use simple bash commands instead of Python imports
- Create `~/.claudemol/bin/claudemol` wrapper script during `setup` with baked Python path
- Rewrite all skill connection patterns from `from claudemol import connect_or_launch` to `~/.claudemol/bin/claudemol exec/launch`
- Simplify SessionStart hook to use the wrapper script
- Bump version to 0.4.0

## Test plan

- [x] `ruff check` passes on changed files
- [x] 10/11 existing tests pass (1 pre-existing flaky test)
- [ ] Manual: `claudemol setup` creates wrapper at `~/.claudemol/bin/claudemol`
- [ ] Manual: `~/.claudemol/bin/claudemol launch` starts PyMOL
- [ ] Manual: `~/.claudemol/bin/claudemol exec "print('hello')"` prints hello

🤖 Generated with [Claude Code](https://claude.com/claude-code)