### PR TITLE
Bump plugin version to 0.4.0

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudemol-skills",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "description": "PyMOL visualization skills for Claude Code - molecular visualization workflows for structural biology",
   "author": {
     "name": "Alex Naka"


### PR DESCRIPTION
## Summary

- Bump `claude-plugin/plugin.json` version from 0.1.0 to 0.4.0 to match the pip package
- Users need to run `/plugin update claudemol-skills` to get the new bash CLI skill patterns

## Test plan

- [ ] `/plugin update claudemol-skills` picks up new version
- [ ] Skills reference `~/.claudemol/bin/claudemol exec` instead of Python imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)