### PR TITLE
Add static and regression tests for untested skill domains

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,16 @@ def parse_frontmatter(path: pathlib.Path) -> dict | None:
     return frontmatter
 
 
+def extract_skill_refs(text: str) -> set[str]:
+    """Extract @skill-name cross-references from text.
+
+    Matches patterns like @pymol-fundamentals, @alphafold-validation, etc.
+    Excludes email-like patterns (word@word) by requiring start-of-line or whitespace.
+    """
+    matches = re.findall(r"(?:^|[\s(,])@([a-z][a-z0-9-]+)", text, re.MULTILINE)
+    return set(matches)
+
+
 def extract_bridge_subcommands(text: str) -> set[str]:
     """Extract pymol-agent-bridge subcommands from text.
 

--- a/tests/test_skill_regression.py
+++ b/tests/test_skill_regression.py
@@ -195,3 +195,241 @@ class TestGuardrailEnforcement:
         assert "cmd.ray" in result_lower or "cmd.png" in result_lower, (
             "Should redirect to cmd.ray()/cmd.png() for image capture"
         )
+
+
+# ---------------------------------------------------------------------------
+# P1 regression tests — untested skill domains
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestMovieCreation:
+    async def test_rotation_movie_advice(self, haiku_options):
+        result = await ask_agent(
+            "How do I create a 360-degree rotation movie of a protein in PyMOL "
+            "and export it as frames?",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must reference movie setup
+        assert "cmd.mset" in result_lower or "mset" in result_lower, (
+            "Should reference cmd.mset() for frame setup"
+        )
+
+        # Must reference rotation or view interpolation
+        assert (
+            "mroll" in result_lower
+            or "mview" in result_lower
+            or "util.mroll" in result_lower
+        ), "Should reference mroll or mview for rotation"
+
+        # Must reference frame export
+        assert "mpng" in result_lower or "cmd.mpng" in result_lower, (
+            "Should reference cmd.mpng() for frame export"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestPublicationFigures:
+    async def test_publication_export_advice(self, haiku_options):
+        result = await ask_agent(
+            "How do I export a publication-quality 300 DPI figure of a protein "
+            "from PyMOL with a white background?",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must reference ray tracing and png export
+        assert "cmd.ray" in result_lower, "Should reference cmd.ray() for rendering"
+        assert "cmd.png" in result_lower, "Should reference cmd.png() for saving"
+
+        # Should mention background or DPI settings
+        bg_refs = {"bg_color", "white", "background", "opaque_background"}
+        found_bg = {ref for ref in bg_refs if ref in result_lower}
+        assert len(found_bg) >= 1, (
+            f"Should reference background settings, found: {found_bg}"
+        )
+
+        # Must NOT use the broken cmd.png(path, width, height) pattern
+        assert "cmd.png(path, width, height)" not in result_lower or "never" in result_lower, (
+            "Should not recommend cmd.png(path, width, height)"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestDesignComparison:
+    async def test_batch_qc_ranking_advice(self, haiku_options):
+        result = await ask_agent(
+            "I have 10 protein designs as PDB files. How do I compare and rank "
+            "them in PyMOL? Show me the key commands.",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must reference grid mode for batch viewing
+        assert "grid_mode" in result_lower or "grid" in result_lower, (
+            "Should reference grid_mode for batch visual QC"
+        )
+
+        # Must reference alignment for comparison
+        align_refs = {"cmd.align", "cmd.super", "cmd.cealign", "rms_cur", "align"}
+        found_align = {ref for ref in align_refs if ref in result_lower}
+        assert len(found_align) >= 1, (
+            f"Should reference alignment commands, found: {found_align}"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestProteinMPNNVisualization:
+    async def test_fixed_vs_designed_and_confidence(self, haiku_options):
+        result = await ask_agent(
+            "How do I visualize ProteinMPNN sequence design results in PyMOL? "
+            "Show designed vs fixed residues and per-position confidence.",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must distinguish fixed vs designed residues
+        assert "fixed" in result_lower or "designed" in result_lower, (
+            "Should distinguish fixed vs designed residues"
+        )
+
+        # Should reference coloring for distinction
+        assert "color" in result_lower, "Should reference coloring for residue distinction"
+
+        # Should reference confidence visualization (B-factor/spectrum)
+        confidence_refs = {"spectrum", "b_factor", "b-factor", "bfactor", "confidence"}
+        found = {ref for ref in confidence_refs if ref in result_lower}
+        assert len(found) >= 1, (
+            f"Should reference confidence visualization, found: {found}"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestRFdiffusionVisualization:
+    async def test_trajectory_and_self_consistency(self, haiku_options):
+        result = await ask_agent(
+            "How do I visualize RFdiffusion outputs in PyMOL? "
+            "Cover trajectory viewing and self-consistency validation.",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must reference trajectory/multi-state viewing
+        traj_refs = {"count_states", "mset", "trajectory", "frame", "states"}
+        found_traj = {ref for ref in traj_refs if ref in result_lower}
+        assert len(found_traj) >= 1, (
+            f"Should reference trajectory/multi-state viewing, found: {found_traj}"
+        )
+
+        # Must reference self-consistency check
+        sc_refs = {"self-consistency", "self_consistency", "rmsd", "align", "af2"}
+        found_sc = {ref for ref in sc_refs if ref in result_lower}
+        assert len(found_sc) >= 1, (
+            f"Should reference self-consistency validation, found: {found_sc}"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestDesignInterfaceAnalysis:
+    async def test_interface_qc_guidance(self, haiku_options):
+        result = await ask_agent(
+            "How do I analyze a protein-protein interface in PyMOL? "
+            "Show me how to identify contacts and hydrogen bonds.",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must reference distance-based interface selection
+        distance_refs = {"within", "around", "byres"}
+        found = {ref for ref in distance_refs if ref in result_lower}
+        assert len(found) >= 1, (
+            f"Should reference distance-based selection, found: {found}"
+        )
+
+        # Must reference hydrogen bond visualization
+        hbond_refs = {"distance", "h-bond", "hbond", "hydrogen bond", "mode=2", "mode 2"}
+        found_hbond = {ref for ref in hbond_refs if ref in result_lower}
+        assert len(found_hbond) >= 1, (
+            f"Should reference hydrogen bond visualization, found: {found_hbond}"
+        )
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"
+
+
+@pytest.mark.slow
+class TestProteinaComplexaWarnings:
+    async def test_ame_chain_and_tmol_guardrail(self, haiku_options):
+        result = await ask_agent(
+            "I want to run Proteina-Complexa AME motif scaffolding. "
+            "Can I keep my ligand on chain C with residue name RET? "
+            "Also, should I enable the TMOL reward for this?",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Must warn about chain A / L:0 requirement
+        chain_refs = {"chain a", "l:0", "rename"}
+        found_chain = {ref for ref in chain_refs if ref in result_lower}
+        assert len(found_chain) >= 1, (
+            f"Should warn about AME chain A / L:0 requirement, found: {found_chain}"
+        )
+
+        # Must warn that TMOL is not supported for AME
+        tmol_refs = {"not supported", "unsupported", "not available", "don't", "do not", "cannot"}
+        found_tmol = {ref for ref in tmol_refs if ref in result_lower}
+        assert len(found_tmol) >= 1, (
+            f"Should warn TMOL is not supported for AME, found: {found_tmol}"
+        )
+
+
+@pytest.mark.slow
+class TestPymolSetupSafety:
+    async def test_requires_user_choice_and_confirmation(self, haiku_options):
+        result = await ask_agent(
+            "Help me set up PyMOL with Claude. Walk me through the process.",
+            haiku_options,
+        )
+        result_lower = result.lower()
+
+        # Should reference checking for existing installation
+        assert "status" in result_lower or "info" in result_lower or "check" in result_lower, (
+            "Should check for existing installation first"
+        )
+
+        # Should reference virtual environment preference
+        venv_refs = {"venv", "virtual environment", "virtualenv", "conda"}
+        found_venv = {ref for ref in venv_refs if ref in result_lower}
+        assert len(found_venv) >= 1, (
+            f"Should mention virtual environment preference, found: {found_venv}"
+        )
+
+        # Should reference pymol-agent-bridge setup
+        assert "setup" in result_lower, "Should reference pymol-agent-bridge setup"
+
+        # Must NOT reference removed utilities
+        for removed in REMOVED_UTILITIES:
+            assert removed not in result_lower, f"Should not reference removed utility: {removed}"

--- a/tests/test_skill_static.py
+++ b/tests/test_skill_static.py
@@ -5,7 +5,14 @@ These tests are free, deterministic, and run by default (no LLM, no API key).
 
 import pathlib
 
-from conftest import REMOVED_UTILITIES, extract_bridge_subcommands, parse_frontmatter
+import re
+
+from conftest import (
+    REMOVED_UTILITIES,
+    extract_bridge_subcommands,
+    extract_skill_refs,
+    parse_frontmatter,
+)
 
 # Skills that only exist in .claude/skills/ (local dev), not distributed
 KNOWN_LOCAL_ONLY = {"rfd3", "skill-development"}
@@ -138,3 +145,127 @@ class TestBridgeCommandsValid:
             if bad:
                 invalid[_skill_name(path)] = bad
         assert not invalid, f"Invalid bridge subcommands found: {invalid}"
+
+
+class TestSkillContentSync:
+    """Distributed and local SKILL.md files should have identical content."""
+
+    def test_skill_md_contents_match(self, repo_root):
+        distributed_dir = repo_root / "claude-plugin" / "skills"
+        local_dir = repo_root / ".claude" / "skills"
+        drifted = []
+        for dist_skill in sorted(distributed_dir.iterdir()):
+            if not dist_skill.is_dir():
+                continue
+            local_skill = local_dir / dist_skill.name
+            if not local_skill.exists():
+                continue  # caught by TestSkillDirectorySync
+            dist_md = dist_skill / "SKILL.md"
+            local_md = local_skill / "SKILL.md"
+            if dist_md.exists() and local_md.exists():
+                if dist_md.read_text() != local_md.read_text():
+                    drifted.append(dist_skill.name)
+        assert not drifted, f"SKILL.md content differs between distributed and local: {drifted}"
+
+
+class TestCrossSkillReferences:
+    """All @skill-name references must point to real skill directories."""
+
+    def test_all_refs_resolve(self, distributed_skill_files, repo_root):
+        skill_dirs = {
+            p.name
+            for p in (repo_root / "claude-plugin" / "skills").iterdir()
+            if p.is_dir()
+        }
+        broken = {}
+        for path in distributed_skill_files:
+            text = path.read_text()
+            refs = extract_skill_refs(text)
+            bad = refs - skill_dirs
+            if bad:
+                broken[_skill_name(path)] = bad
+        assert not broken, f"Broken @skill references: {broken}"
+
+
+class TestFrontmatterSemantics:
+    """Frontmatter values should be consistent and well-formed."""
+
+    # Skills where frontmatter name intentionally differs from directory name
+    KNOWN_NAME_EXCEPTIONS = {"skill-development"}
+
+    def test_name_matches_directory(self, distributed_skill_files):
+        mismatched = []
+        for path in distributed_skill_files:
+            name = _skill_name(path)
+            if name in self.KNOWN_NAME_EXCEPTIONS:
+                continue
+            fm = parse_frontmatter(path)
+            if fm is None:
+                continue
+            if fm.get("name") != name:
+                mismatched.append(f"{name}: name={fm.get('name')!r}")
+        assert not mismatched, f"Frontmatter name doesn't match directory: {mismatched}"
+
+    def test_version_is_semver(self, distributed_skill_files):
+        invalid = []
+        for path in distributed_skill_files:
+            fm = parse_frontmatter(path)
+            if fm is None or "version" not in fm:
+                continue
+            if not re.match(r"^\d+\.\d+\.\d+$", fm["version"]):
+                invalid.append(
+                    f"{_skill_name(path)}: version={fm['version']!r}"
+                )
+        assert not invalid, f"Non-semver version strings: {invalid}"
+
+
+class TestImageCaptureSafety:
+    """No skill should use the broken cmd.png(path, width, height) pattern."""
+
+    def test_no_broken_cmd_png_signature(self, distributed_skill_files):
+        # Match cmd.png calls with 3+ positional args (the broken pattern).
+        # Allow cmd.png(path) and cmd.png(path, dpi=300) (keyword args are fine).
+        # Exclude commented-out lines (skills may document the anti-pattern).
+        pattern = re.compile(
+            r"cmd\.png\(\s*"
+            r"[^)]+,"   # first arg + comma
+            r"\s*\d+"   # second arg is a bare number (width)
+            r"\s*,"     # comma
+            r"\s*\d+"   # third arg is a bare number (height)
+        )
+        violations = []
+        for path in distributed_skill_files:
+            text = path.read_text()
+            for line in text.splitlines():
+                stripped = line.lstrip()
+                # Skip comment lines (documenting the anti-pattern)
+                if stripped.startswith("#") or stripped.startswith("//"):
+                    continue
+                if pattern.search(line):
+                    violations.append(_skill_name(path))
+                    break
+        assert not violations, (
+            f"Skills using broken cmd.png(path, width, height) pattern "
+            f"(causes view corruption): {violations}"
+        )
+
+
+class TestNoReinitializeExamples:
+    """No skill should contain cmd.reinitialize() in executable code examples."""
+
+    def test_distributed_skills(self, distributed_skill_files):
+        violations = []
+        for path in distributed_skill_files:
+            text = path.read_text()
+            for line in text.splitlines():
+                stripped = line.lstrip()
+                # Skip lines that are warnings/rules about reinitialize
+                if stripped.startswith(("#", "-", ">", "*", "//", "`")):
+                    continue
+                if "cmd.reinitialize()" in line:
+                    violations.append(_skill_name(path))
+                    break
+        assert not violations, (
+            f"Skills containing cmd.reinitialize() in code examples "
+            f"(destroys user state): {violations}"
+        )


### PR DESCRIPTION
## Summary
- **6 P0 static tests** (free, deterministic): content sync, cross-skill @reference validation, frontmatter semantics, cmd.png anti-pattern detection, cmd.reinitialize detection
- **8 P1 Haiku regression tests**: movie creation, publication figures, design comparison, ProteinMPNN viz, RFdiffusion viz, interface analysis, Proteina-Complexa AME guardrails, PyMOL setup safety
- **1 conftest helper**: `extract_skill_refs()` for cross-reference extraction

Covers 8 previously untested skill domains. Static tests caught 3 real issues during development (content in comment/warning context).

## Test plan
- [x] Static tests pass (`pytest tests/test_skill_static.py` — 14/14 pass)
- [x] All tests collect without errors (`--collect-only` — 41 tests)
- [ ] Regression tests pass with API key (`pytest -m slow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)